### PR TITLE
Add basic Kotlin app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # v2x-net-tracker
+
+This repository now contains a simple Kotlin application using Gradle.
+
+## Building and Running
+
+Use Gradle to build and execute the application:
+
+```bash
+./gradlew run
+```
+
+The main entry point prints a greeting to the console.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm") version "1.8.20"
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+application {
+    mainClass.set("MainKt")
+}
+
+kotlin {
+    jvmToolchain(11)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "v2x-net-tracker"

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("Hello, Kotlin!")
+}


### PR DESCRIPTION
## Summary
- initialize a simple Kotlin application using Gradle
- document how to build and run the app

## Testing
- `gradle build --no-daemon --console=plain` *(fails: plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68627a5ec6a48325addb2cf2bc0e65f2